### PR TITLE
Changes setConfig readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ If you are on Sage 10 and using my [ACF Composer](https://github.com/log1x/acf-c
 ```php
 $field
   ->addField('my_color_field', 'editor_palette')
-    ->setConfig('default_value' => 'green-500')
-    ->setConfig('return_value' => 'slug');
+    ->setConfig('default_value', 'green-500')
+    ->setConfig('return_value', 'slug');
 ```
 
 ## Todo

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you are on Sage 10 and using my [ACF Composer](https://github.com/log1x/acf-c
 $field
   ->addField('my_color_field', 'editor_palette')
     ->setConfig('default_value', 'green-500')
-    ->setConfig('return_value', 'slug');
+    ->setConfig('return_format', 'slug');
 ```
 
 ## Todo


### PR DESCRIPTION
I think `=>` should be `,` and `'return_value'` should be `'return_format'` in setConfig:

```
$field
  ->addField('my_color_field', 'editor_palette')
    ->setConfig('default_value', 'green-500')
    ->setConfig('return_format', 'slug');
```

P.s. thanks for sharing this awesome plugin!