### PR TITLE
Always add core components styles

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -228,6 +228,10 @@ class Field extends \acf_field
      */
     public function input_admin_enqueue_scripts()
     {
+        if ( ! wp_script_is('wp-components', 'enqueued') ) {
+            wp_enqueue_style( 'wp-components' );
+        }
+        
         wp_enqueue_style($this->name, $this->asset('css/field.css'), [], null);
         wp_enqueue_script($this->name, $this->asset('js/field.js'), [], null, true);
     }

--- a/src/Field.php
+++ b/src/Field.php
@@ -228,8 +228,8 @@ class Field extends \acf_field
      */
     public function input_admin_enqueue_scripts()
     {
-        if ( ! wp_script_is('wp-components', 'enqueued') ) {
-            wp_enqueue_style( 'wp-components' );
+        if (! wp_script_is('wp-components', 'enqueued')) {
+            wp_enqueue_style('wp-components');
         }
         
         wp_enqueue_style($this->name, $this->asset('css/field.css'), [], null);


### PR DESCRIPTION
Add core components styles when adding ACF color field to the blog page, options page or other place where the block editor styles are not loaded.

Fixing:
![image](https://user-images.githubusercontent.com/50170696/102714270-b8bc2900-42cd-11eb-8dc2-07ba481bcd08.png)
