### PR TITLE
Fix `Undefined index: exclude_colors` notice/error

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -74,7 +74,7 @@ class Field extends \acf_field
         }
 
         $palette = array_filter($palette, function ($color) use ($field) {
-            return ! in_array($color['slug'], $field['exclude_colors'] ?: []);
+            return ! in_array($color['slug'], $field['exclude_colors'] ?? []);
         });
 
         $active = is_array($field['value']) ? $field['value']['slug'] : $field['value'];


### PR DESCRIPTION
**Summary**
If `exclude_colors` is not set when using ACF Builder/Composer the admin errors and never loads the ACF Block settings.
```php
Error: Undefined index: exclude_colors
...
plugins/acf-editor-palette/src/Field.php78
```

 It's possible to work around this by adding the exclude config to sage10/acf-composer defaults ie:
```php
# sage/app/config/acf.php

'defaults' => [
    'select'           => ['ui' => 1],
    ...
    'editor_palette'   => ['return_format' => 'slug', 'exclude_colors' => []],
];
```

Or add it to each field config:
```php
$field->addField('my_color_field', 'editor_palette', [
    'exclude_colors' => [],
]);
```