### PR TITLE
On update_value check if value is string

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -262,8 +262,12 @@ class Field extends \acf_field
      */
     public function update_value($value, $post_id, $field)
     {
-        if (empty($value)) return $value;
+        if (empty($value)) {
+            return $value;
+        }
+        
         $value = is_string($value) ? $value : $value['slug'];
+        
         return $this->palette($value);
     }
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -265,9 +265,9 @@ class Field extends \acf_field
         if (empty($value)) {
             return $value;
         }
-        
+
         $value = is_string($value) ? $value : $value['slug'];
-        
+
         return $this->palette($value);
     }
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -262,7 +262,9 @@ class Field extends \acf_field
      */
     public function update_value($value, $post_id, $field)
     {
-        return ! empty($value) ? $this->palette($value) : $value;
+        if (empty($value)) return $value;
+        $value = is_string($value) ? $value : $value['slug'];
+        return $this->palette($value);
     }
 
     /**


### PR DESCRIPTION
### This PR
- [x] Adds a check if value is_string

### Context 
In some cases when copying flexible layouts, value would default to `white`, because instead of actual `$value` which is a `slug`, `$color` object would be sent. 

With this case if value is not empty and it's not string we can be sure that the value is color object and we can pull the `slug` which will result in correct result. 