### PR TITLE
fix(acp): Fix Admin Columns Pro integration when return format is not an array

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -13,7 +13,9 @@ namespace Log1x\AcfEditorPalette;
 
 add_filter('after_setup_theme', new class
 {
-   /**
+    use Concerns\Palette;
+
+    /**
      * The field label.
      *
      * @var string
@@ -98,11 +100,14 @@ add_filter('after_setup_theme', new class
         add_filter('ac/column/value', function ($value, $id, $column) {
             if (
                 ! is_a($column, '\ACA\ACF\Column') ||
-                $column->get_field_type() !== $this->name ||
-                empty($color = get_field($column->get_meta_key())) ||
-                ! is_array($color)
+                $column->get_acf_field_option('type') !== $this->name ||
+                empty($color = get_field($column->get_meta_key()))
             ) {
                 return $value;
+            }
+
+            if (! is_array($color)) {
+                $color = $this->palette($color);
             }
 
             return sprintf(

--- a/src/Concerns/Palette.php
+++ b/src/Concerns/Palette.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Log1x\AcfEditorPalette\Concerns;
+
+trait Palette
+{
+    /**
+     * Retrieve the editor color palette.
+     *
+     * @param  string $color
+     * @return string[]
+     */
+    public function palette($color = null)
+    {
+        $colors = [];
+        $themeJson = [];
+
+        $palette = (array) current(
+            get_theme_support('editor-color-palette')
+        );
+
+        if (function_exists('wp_get_global_settings')) {
+            $themeJson = wp_get_global_settings(['color', 'palette', 'theme']);
+        }
+
+        if (! isset($themeJson['border'])) {
+            $palette = array_merge($palette, $themeJson);
+        }
+
+        if (empty($palette)) {
+            return $color ?: $colors;
+        }
+
+        foreach ($palette as $value) {
+            $colors = array_merge($colors, [
+                $value['slug'] => array_merge($value, [
+                    'text' => sprintf('has-text-color has-%s-color', $value['slug']),
+                    'background' => sprintf('has-background has-%s-background-color', $value['slug']),
+                ])
+            ]);
+        }
+
+        return ! empty($color) ? $colors[$color] : $colors;
+    }
+}

--- a/src/Field.php
+++ b/src/Field.php
@@ -5,6 +5,7 @@ namespace Log1x\AcfEditorPalette;
 class Field extends \acf_field
 {
     use Concerns\Asset;
+    use Concerns\Palette;
 
     /**
      * The default field values.
@@ -32,45 +33,6 @@ class Field extends \acf_field
         $this->path = $plugin->path;
 
         parent::__construct();
-    }
-
-    /**
-     * Retrieve the editor color palette.
-     *
-     * @param  string $color
-     * @return string[]
-     */
-    protected function palette($color = null)
-    {
-        $colors = [];
-        $themeJson = [];
-
-        $palette = (array) current(
-            get_theme_support('editor-color-palette')
-        );
-
-        if (function_exists('wp_get_global_settings')) {
-            $themeJson = wp_get_global_settings(['color', 'palette', 'theme']);
-        }
-
-        if (! isset($themeJson['border'])) {
-            $palette = array_merge($palette, $themeJson);
-        }
-
-        if (empty($palette)) {
-            return $color ?: $colors;
-        }
-
-        foreach ($palette as $value) {
-            $colors = array_merge($colors, [
-                $value['slug'] => array_merge($value, [
-                    'text' => sprintf('has-text-color has-%s-color', $value['slug']),
-                    'background' => sprintf('has-background has-%s-background-color', $value['slug']),
-                ])
-            ]);
-        }
-
-        return ! empty($color) ? $colors[$color] : $colors;
     }
 
     /**


### PR DESCRIPTION
Very confused. In some environments, I'm finding `get_field_type()` to be throwing an exception (due to it missing on the `Column` class), `get_type()` is not ACF specific, and `get_acf_field_option('type')` is apparently deprecated (but still works & works as intended).

...not sure which one I'm supposed to be using. Their [hook reference](https://github.com/codepress/admin-columns-hooks/blob/master/ac-column-value.php) hasn't been updated to reflect any changes to [`get_acf_field_option`](https://github.com/codepress/admin-columns-hooks/blob/master/ac-column-value.php#L154)...