### PR TITLE
fix(field): Ensure value is not empty before parsing through `palette()`

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Advanced Custom Fields: Editor Palette Field
  * Plugin URI:  https://github.com/log1x/acf-editor-palette
  * Description: A Gutenberg-like editor palette color picker field for Advanced Custom Fields.
- * Version:     1.1.1
+ * Version:     1.1.2
  * Author:      Brandon Nifong
  * Author URI:  https://github.com/log1x
  */

--- a/src/Field.php
+++ b/src/Field.php
@@ -236,7 +236,7 @@ class Field extends \acf_field
     {
         $format = $field['return_format'] ?? $this->defaults['return_format'];
 
-        if (is_string($value)) {
+        if (! empty($value) && is_string($value)) {
             $value = $this->palette($value);
         }
 


### PR DESCRIPTION
## Change log

### Bug fixes

* fix(field): Ensure value is not empty before parsing through `palette()`