### PR TITLE
fix(field): Return null if palette slug is invalid

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Advanced Custom Fields: Editor Palette Field
  * Plugin URI:  https://github.com/log1x/acf-editor-palette
  * Description: A Gutenberg-like editor palette color picker field for Advanced Custom Fields.
- * Version:     1.1.2
+ * Version:     1.1.3
  * Author:      Brandon Nifong
  * Author URI:  https://github.com/log1x
  */

--- a/src/Field.php
+++ b/src/Field.php
@@ -70,7 +70,9 @@ class Field extends \acf_field
             ]);
         }
 
-        return ! empty($color) ? $colors[$color] : $colors;
+        return ! empty($color) ? (
+            $colors[$color] ?? null
+        ) : $colors;
     }
 
     /**


### PR DESCRIPTION
Immediately hit this issue after releasing v1.1.2 on a site returning an invalid color value due to legacy purposes. :(

## Change log

### Bug fixes

- fix(field): Return null if palette slug is invalid