### PR TITLE
fix(field): Fix potential exception when editor palette is empty (Fixes #43)

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Advanced Custom Fields: Editor Palette Field
  * Plugin URI:  https://github.com/log1x/acf-editor-palette
  * Description: A Gutenberg-like editor palette color picker field for Advanced Custom Fields.
- * Version:     1.1.3
+ * Version:     1.1.4
  * Author:      Brandon Nifong
  * Author URI:  https://github.com/log1x
  */

--- a/src/Concerns/Palette.php
+++ b/src/Concerns/Palette.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Log1x\AcfEditorPalette\Concerns;
+
+trait Palette
+{
+    /**
+     * Retrieve the editor color palette.
+     *
+     * @param  string $color
+     * @return string[]
+     */
+    public function palette($color = null)
+    {
+        $colors = [];
+        $themeJson = [];
+
+        $palette = (array) current(
+            get_theme_support('editor-color-palette') ?? []
+        );
+
+        if (function_exists('wp_get_global_settings')) {
+            $themeJson = wp_get_global_settings(['color', 'palette', 'theme']);
+        }
+
+        if (! isset($themeJson['border'])) {
+            $palette = array_merge($palette, $themeJson);
+        }
+
+        if (empty($palette)) {
+            return $color ?: $colors;
+        }
+
+        foreach ($palette as $value) {
+            $colors = array_merge($colors, [
+                $value['slug'] => array_merge($value, [
+                    'text' => sprintf('has-text-color has-%s-color', $value['slug']),
+                    'background' => sprintf('has-background has-%s-background-color', $value['slug']),
+                ])
+            ]);
+        }
+
+        return ! empty($color) ? (
+            $colors[$color] ?? null
+        ) : $colors;
+    }
+}

--- a/src/Field.php
+++ b/src/Field.php
@@ -5,6 +5,7 @@ namespace Log1x\AcfEditorPalette;
 class Field extends \acf_field
 {
     use Concerns\Asset;
+    use Concerns\Palette;
 
     /**
      * The default field values.
@@ -32,47 +33,6 @@ class Field extends \acf_field
         $this->path = $plugin->path;
 
         parent::__construct();
-    }
-
-    /**
-     * Retrieve the editor color palette.
-     *
-     * @param  string $color
-     * @return string[]
-     */
-    protected function palette($color = null)
-    {
-        $colors = [];
-        $themeJson = [];
-
-        $palette = (array) current(
-            get_theme_support('editor-color-palette')
-        );
-
-        if (function_exists('wp_get_global_settings')) {
-            $themeJson = wp_get_global_settings(['color', 'palette', 'theme']);
-        }
-
-        if (! isset($themeJson['border'])) {
-            $palette = array_merge($palette, $themeJson);
-        }
-
-        if (empty($palette)) {
-            return $color ?: $colors;
-        }
-
-        foreach ($palette as $value) {
-            $colors = array_merge($colors, [
-                $value['slug'] => array_merge($value, [
-                    'text' => sprintf('has-text-color has-%s-color', $value['slug']),
-                    'background' => sprintf('has-background has-%s-background-color', $value['slug']),
-                ])
-            ]);
-        }
-
-        return ! empty($color) ? (
-            $colors[$color] ?? null
-        ) : $colors;
     }
 
     /**


### PR DESCRIPTION
## Change log

### Enhancements

* enhance(plugin): Move `palette()` to a trait to allow usage outside of plugin

### Bug fixes

* fix(field): Fix potential exception when editor palette is empty (Fixes #43)