### PR TITLE
feat(field): Add allowed colors field group setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Gutenberg-like editor palette color picker field for Advanced Custom Fields.
 - Colors are automatically loaded from `theme.json` and/or the editor palette.
 - Return format includes the default [palette keys](https://developer.wordpress.org/block-editor/developers/themes/theme-support/) as well as background and text color classes for convenience.
 - Default value can optionally be set using the color's slug.
-- Colors can optionally be excluded from the palette.
+- Colors can optionally be allowed/excluded from the palette.
 
 ## Requirements
 
@@ -56,6 +56,7 @@ If you are on Sage 10 and using my [ACF Composer](https://github.com/log1x/acf-c
 $field
   ->addField('my_color_field', 'editor_palette')
     ->setConfig('default_value', 'green-500')
+    ->setConfig('allowed_colors', ['green-500', 'blue-500'])
     ->setConfig('exclude_colors', ['green-50', 'green-100'])
     ->setConfig('return_format', 'slug');
 ```

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Advanced Custom Fields: Editor Palette Field
  * Plugin URI:  https://github.com/log1x/acf-editor-palette
  * Description: A Gutenberg-like editor palette color picker field for Advanced Custom Fields.
- * Version:     1.1.4
+ * Version:     1.1.5
  * Author:      Brandon Nifong
  * Author URI:  https://github.com/log1x
  */

--- a/src/Concerns/Palette.php
+++ b/src/Concerns/Palette.php
@@ -16,7 +16,7 @@ trait Palette
         $themeJson = [];
 
         $palette = (array) current(
-            get_theme_support('editor-color-palette') ?? []
+            get_theme_support('editor-color-palette') ?: []
         );
 
         if (function_exists('wp_get_global_settings')) {
@@ -32,6 +32,10 @@ trait Palette
         }
 
         foreach ($palette as $value) {
+            if (empty($value['slug'])) {
+                return;
+            }
+
             $colors = array_merge($colors, [
                 $value['slug'] => array_merge($value, [
                     'text' => sprintf('has-text-color has-%s-color', $value['slug']),

--- a/src/Field.php
+++ b/src/Field.php
@@ -138,7 +138,7 @@ class Field extends \acf_field
         $colors = [];
 
         if (empty($palette = $this->palette())) {
-           return acf_render_field_setting($field, [
+            return acf_render_field_setting($field, [
                 'label' => __('No color palette found.', 'acf-editor-palette'),
                 'name' => 'color_palette_empty',
                 'instructions' => __('You must have a color palette to use this field.', 'acf-editor-palette'),

--- a/src/Field.php
+++ b/src/Field.php
@@ -14,6 +14,7 @@ class Field extends \acf_field
      */
     public $defaults = [
         'default_value' => null,
+        'allowed_colors' => [],
         'exclude_colors' => [],
         'return_format' => 'slug',
     ];
@@ -44,15 +45,22 @@ class Field extends \acf_field
     public function render_field($field)
     {
         if (empty($palette = $this->palette())) {
+            echo __('The theme editor palette is empty.', 'acf-editor-palette');
             return;
         }
 
-        $palette = array_filter($palette, function ($color) use ($field) {
-            return ! in_array(
-                $color['slug'],
-                ! empty($field['exclude_colors']) && is_array($field['exclude_colors']) ? $field['exclude_colors'] : []
-            );
-        });
+        if (! empty($excluded = $field['exclude_colors']) && is_array($excluded)) {
+            $palette = array_filter($palette, function ($color) use ($excluded) {
+                return ! in_array($color['slug'], $excluded);
+            });
+        }
+
+
+        if (! empty($allowed = $field['allowed_colors']) && is_array($allowed)) {
+            $palette = array_filter($palette, function ($color) use ($allowed) {
+                return in_array($color['slug'], $allowed);
+            });
+        }
 
         $active = is_array($field['value']) ? $field['value']['slug'] : $field['value'];
 
@@ -129,7 +137,17 @@ class Field extends \acf_field
     {
         $colors = [];
 
-        foreach ($this->palette() as $item) {
+        if (empty($palette = $this->palette())) {
+           return acf_render_field_setting($field, [
+                'label' => __('No color palette found.', 'acf-editor-palette'),
+                'name' => 'color_palette_empty',
+                'instructions' => __('You must have a color palette to use this field.', 'acf-editor-palette'),
+                'type' => 'message',
+                'message' => __('The theme editor palette is empty. Add a color palette using <a target="_blank" rel="noopener noreferrer" href="https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/">theme.json</a> or <a target="_blank" rel="noopener noreferrer" href="https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#block-color-palettes">add_theme_support()</a>.', 'acf-editor-palette'), // phpcs:ignore
+            ]);
+        }
+
+        foreach ($palette as $item) {
             $colors[$item['slug']] = sprintf(
                 '<span style="display: inline-block;
                     background-color: %s;
@@ -152,20 +170,33 @@ class Field extends \acf_field
             'ui' => '1',
             'default_value' => null,
             'allow_null' => true,
-            'placeholder' => __('Select a color (optional)', 'acf-editor-palette'),
+            'placeholder' => __('Select a default color (optional)', 'acf-editor-palette'),
+            'choices' => $colors,
+        ]);
+
+        acf_render_field_setting($field, [
+            'label' => __('Allowed Colors', 'acf-editor-palette'),
+            'name' => 'allowed_colors',
+            'instructions' => __('Allow colors from the palette.', 'acf-editor-palette'),
+            'type' => 'select',
+            'ui' => '1',
+            'default_value' => null,
+            'allow_null' => true,
+            'multiple' => true,
+            'placeholder' => __('Select allowed colors (optional)', 'acf-editor-palette'),
             'choices' => $colors,
         ]);
 
         acf_render_field_setting($field, [
             'label' => __('Exclude Colors', 'acf-editor-palette'),
             'name' => 'exclude_colors',
-            'instructions' => __('Exclude colors from palette.', 'acf-editor-palette'),
+            'instructions' => __('Exclude colors from the palette.', 'acf-editor-palette'),
             'type' => 'select',
             'ui' => '1',
             'default_value' => null,
             'allow_null' => true,
             'multiple' => true,
-            'placeholder' => __('Select colors (optional)', 'acf-editor-palette'),
+            'placeholder' => __('Select excluded colors (optional)', 'acf-editor-palette'),
             'choices' => $colors,
         ]);
 


### PR DESCRIPTION
## Change log

### Enhancements

- feat(field): Add allowed colors field group setting
- enhance(field): Add additional conditionals to handle empty color palettes (Fixes #43)
- enhance(field): Render friendly field message when editor palette could not be found
- chore(field): Improve localization in field setting placeholders and instructions
- chore(docs): Update README to include mention of `allowed_colors`