### PR TITLE
Override palette with custom_colors setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ $field
     ->setConfig('default_value', 'green-500')
     ->setConfig('allowed_colors', ['green-500', 'blue-500'])
     ->setConfig('exclude_colors', ['green-50', 'green-100'])
+    ->setConfig('custom_color', [
+      'name' => 'Magenta',
+      'slug' => 'magenta',
+      'color' => '#ff00ff',
+    ]);
     ->setConfig('return_format', 'slug');
 ```
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -16,6 +16,7 @@ class Field extends \acf_field
         'default_value' => null,
         'allowed_colors' => [],
         'exclude_colors' => [],
+        'custom_colors' => [],
         'return_format' => 'slug',
     ];
 
@@ -55,11 +56,14 @@ class Field extends \acf_field
             });
         }
 
-
         if (! empty($allowed = $field['allowed_colors']) && is_array($allowed)) {
             $palette = array_filter($palette, function ($color) use ($allowed) {
                 return in_array($color['slug'], $allowed);
             });
+        }
+
+        if (! empty($custom_colors = $field['custom_colors']) && is_array($custom_colors)) {
+            $palette = $custom_colors;
         }
 
         if (empty($palette)) {


### PR DESCRIPTION
### Summary

Following up on #53 - this PR adds the ability to override the palette with `custom_colors` setting. It doesn't solve the issue of the ACF admin UI, which will probably need a lot more thought.

### Example
```php
$terms_options
    ->addField('using_theme_palette', 'editor_palette')
    ->addField('using_custom_colors', 'editor_palette', [
        'custom_colors' => [
            [
                'name' => 'Cyan',
                'slug' => 'cyan',
                'color' => '#00ffff',
            ],
            [
                'name' => 'Magenta',
                'slug' => 'magenta',
                'color' => '#ff00ff',
            ],
            [
                'name' => 'Yellow',
                'slug' => 'yellow',
                'color' => '#ffff00',
            ],
            [
                'name' => 'Black',
                'slug' => 'black',
                'color' => '#000000',
            ],
        ],
    ]);

```


### Preview

![2023-09-07 2019 - Google Chrome](https://github.com/Log1x/acf-editor-palette/assets/1690006/9b756cc2-a55f-4abc-bee7-42f19acece0b)
