### PR TITLE
🩹 Remove styling from field settings

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Advanced Custom Fields: Editor Palette Field
  * Plugin URI:  https://github.com/log1x/acf-editor-palette
  * Description: A Gutenberg-like editor palette color picker field for Advanced Custom Fields.
- * Version:     1.1.6
+ * Version:     1.1.7
  * Author:      Brandon Nifong
  * Author URI:  https://github.com/log1x
  */

--- a/src/Field.php
+++ b/src/Field.php
@@ -153,18 +153,7 @@ class Field extends \acf_field
         }
 
         foreach ($palette as $item) {
-            $colors[$item['slug']] = sprintf(
-                '<span style="display: inline-block;
-                    background-color: %s;
-                    width: 1em;
-                    height: 1em;
-                    margin: 0 3px -3px;
-                    border: 1px solid #ccd0d4;
-                    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);"
-                ></span> %s',
-                $item['color'],
-                $item['name']
-            );
+            $colors[$item['slug']] = $item['name'];
         }
 
         acf_render_field_setting($field, [


### PR DESCRIPTION
ACF v6.2.7 now filters HTML in Select2 drop downs. I removed the styling for now but maybe a future PR can implement a custom Select2 to handle rendering.

- https://github.com/Log1x/acf-editor-palette/issues/31#issuecomment-2015741652
- https://www.advancedcustomfields.com/blog/acf-6-2-7-security-release/