### PR TITLE
Fix: check icon not being on top of the color option

### DIFF
--- a/assets/css/field.scss
+++ b/assets/css/field.scss
@@ -23,6 +23,12 @@
         .components-circular-option-picker__option {
           @apply p-0;
         }
+
+        svg {
+          position: absolute;
+          top: 2px;
+          left: 2px;
+        }
       }
     }
   }


### PR DESCRIPTION
Before:
![image](https://github.com/Log1x/acf-editor-palette/assets/50170696/32031ee5-c3c1-403d-b9b8-2d96639de7be)

After:
![image](https://github.com/Log1x/acf-editor-palette/assets/50170696/8d24ab45-0f7a-4300-abaf-fb27504bd0e7)
