### PR TITLE
Better GraphQL typings

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -82,6 +82,23 @@ add_filter('after_setup_theme', new class
                 return new Field($this);
             });
         }
+
+        if (function_exists('register_graphql_acf_field_type')) {
+            add_action('wpgraphql/acf/registry_init', function () {
+                register_graphql_acf_field_type($this->name, [
+                    'graphql_type' => 'string',
+                    'resolve' => function ($root, $args, $context, $info, $field_config) {
+                        $value = $field_config->resolve_field($root, $args, $context, $info);
+
+                        if (is_null($value)) {
+                            return null;
+                        }
+
+                        return $value['slug'];
+                    },
+                ]);
+            });
+        }
     }
 
     /**

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Advanced Custom Fields: Editor Palette Field
  * Plugin URI:  https://github.com/log1x/acf-editor-palette
  * Description: A Gutenberg-like editor palette color picker field for Advanced Custom Fields.
- * Version:     1.2.0
+ * Version:     1.2.1
  * Author:      Brandon Nifong
  * Author URI:  https://github.com/log1x
  */


### PR DESCRIPTION
Hello Brandon,

I contributed a patch a few months ago to allow editor_palette fields to be queried with GraphQL (I am possible the only person on the planet who cares if that works). 

The previous patch returned the slug for the colour, which i realised is a bit lazy since GraphQL should let you decide the return format. So I updated the function to allow the user to choose which return format they would like.

Have tested this and it relies on register_graphql_acf_field_type which has been around forever so this should be a very straightforward merge, if you would care to accept. 

thanks again for all your amazing plugins, use your stuff all the time! cheers 