### PR TITLE
Fix for a duplicate swatch on block re render

### DIFF
--- a/assets/field.js
+++ b/assets/field.js
@@ -65,6 +65,10 @@
       }
 
       $(this)
+        .find('.acf-label label .component-color-indicator')
+        .remove()
+
+      $(this)
         .find('.acf-label label')
         .append(
           `<span class="component-color-indicator" style="display: none;"></span>`


### PR DESCRIPTION
When using ACF Composer and the Editor palette - the selected swatch would get re-appended when you update any fields on the block that causes a re-render in the editor.

This fix just checks for existing swatches, and removes them before appending a new one.