### PR TITLE
fix: fix editor palette field initialization and event handling

### DIFF
--- a/assets/field.js
+++ b/assets/field.js
@@ -1,88 +1,86 @@
-;(function($) {
+(function ($) {
   if (typeof acf.add_action === 'undefined') {
     return
   }
 
   const tinycolor = require('tinycolor2')
 
-  /**
-   * The hook below is fired when initializing
-   * new or existing editor palette fields.
-   *
-   * @param {jQuery} element
-   */
-  acf.add_action('ready append', function(element) {
-    acf.get_fields({ type: 'editor_palette' }, element).each(function() {
-      const onChange = () => {
-        let current = $(this).find('.acf-input li input + label.is-pressed')
-        let selected = $(this).find('.acf-input li input:checked + label')
+  acf.add_action('new_field/type=editor_palette', function ($field, context) {
+    initializeField($field);
+  });
 
-        if ((!selected.length && !current.length) || current === selected) {
-          return
-        }
+  function initializeField($field) {
 
-        let color = {
-          value: selected.data('color'),
-          inverted: tinycolor(selected.data('color')).isLight()
-            ? '#000'
-            : '#fff',
-        }
+    const onChange = () => {
+      let current = $field.find('.acf-input li input + label.is-pressed')
+      let selected = $field.find('.acf-input li input:checked + label')
 
-        let checkmark = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="${color.inverted}" role="img" aria-hidden="true" focusable="false"><path d="M18.3 5.6L9.9 16.9l-4.6-3.4-.9 1.2 5.8 4.3 9.3-12.6z"></path></svg>`
-
-        current
-          .removeClass('is-pressed')
-          .parent()
-          .find('svg')
-          .remove()
-        selected.addClass('is-pressed').after(checkmark)
-
-        $(this)
-          .find('.component-color-indicator')
-          .show()
-          .attr({
-            'aria-label': `(Color: ${color.value || 'Current'})`,
-            style: `background: ${color.value || 'Current'};`,
-          })
+      if ((!selected.length && !current.length) || current === selected) {
+        return
       }
 
-      const onClear = () => {
-        $ref = $(this);
-        $ref.find('.acf-input li input').attr('checked', false)
-        $ref.find('.acf-input li input + label')
-          .removeClass('is-pressed')
-          .parent()
-          .find('svg')
-          .remove()
-
-        $(this)
-          .find('.component-color-indicator')
-          .hide()
-
-        $(this)
-          .find('.empty-value')
-          .click();
+      let color = {
+        value: selected.data('color'),
+        inverted: tinycolor(selected.data('color')).isLight()
+          ? '#000'
+          : '#fff',
       }
 
-      $(this)
-        .find('.acf-label label .component-color-indicator')
+      let checkmark = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="${color.inverted}" role="img" aria-hidden="true" focusable="false"><path d="M18.3 5.6L9.9 16.9l-4.6-3.4-.9 1.2 5.8 4.3 9.3-12.6z"></path></svg>`
+
+      current
+        .removeClass('is-pressed')
+        .parent()
+        .find('svg')
+        .remove()
+      selected.addClass('is-pressed').after(checkmark)
+
+      $field
+        .find('.component-color-indicator')
+        .show()
+        .attr({
+          'aria-label': `(Color: ${color.value || 'Current'})`,
+          style: `background: ${color.value || 'Current'};`,
+        })
+    }
+
+    const onClear = () => {
+      $ref = $field;
+      $ref.find('.acf-input li input').attr('checked', false)
+      $ref.find('.acf-input li input + label')
+        .removeClass('is-pressed')
+        .parent()
+        .find('svg')
         .remove()
 
-      $(this)
-        .find('.acf-label label')
-        .append(
-          `<span class="component-color-indicator" style="display: none;"></span>`
-        )
+      $field
+        .find('.component-color-indicator')
+        .hide()
 
-      $(this)
-        .find('.components-circular-option-picker__clear')
-        .on('click', () => onClear())
+      $field
+        .find('.empty-value')
+        .click();
+    }
 
-      $(this)
-        .find('.acf-input li')
-        .on('click', () => onChange())
+    $field
+      .find('.acf-label label .component-color-indicator')
+      .remove()
 
-      onChange()
-    })
-  })
+    $field
+      .find('.acf-label label')
+      .append(
+        `<span class="component-color-indicator" style="display: none;"></span>`
+      )
+
+    $field
+      .find('.components-circular-option-picker__clear')
+      .on('click', () => onClear())
+
+    $field
+      .find('.acf-input li')
+      .on('click', () => onChange())
+
+    onChange()
+  }
+
 })(jQuery)


### PR DESCRIPTION
Since a few versions of ACF ago the clear button was not working and checkmark was not being displayed and thus making it very hard to interact with a field. With these changes fields are once again showing up. 

I've tested this code against ACF 6.8.1 and tested repeater fields, block fields, block fields in the new expanded editor, conditional fields. So I hope that pretty much covers everything @Log1x .